### PR TITLE
add background colour enabler, and make some refactoring

### DIFF
--- a/lib/highlight-line-view.coffee
+++ b/lib/highlight-line-view.coffee
@@ -7,6 +7,7 @@ underlineStyleInUsed = ''
 
 module.exports =
   configDefaults:
+    allEnable: true
     enableBackgroundColor: true
     backgroundRgbColor: "100, 100, 100"
     opacity: "50%"
@@ -80,7 +81,8 @@ class HighlightLineView extends View
 
   updateSelectedLine: =>
     @resetBackground()
-    @showHighlight()
+    if atom.config.get('highlight-line.allEnable')
+      @showHighlight()
 
   resetBackground: ->
     $('.line').css('background-color', '')
@@ -93,7 +95,7 @@ class HighlightLineView extends View
       bgColor = @wantedColor('backgroundRgbColor')
       bgRgba = "rgba(#{bgColor}, #{@wantedOpacity()})"
       styleAttr += "background-color: #{bgRgba};"
-    if underlineStyleInUsed isnt
+    if underlineStyleInUsed
       ulColor = @wantedColor('underlineRgbColor')
       ulRgba = "rgba(#{ulColor},1)"
       styleAttr += "border-bottom: 1px #{underlineStyleInUsed} #{ulRgba};"


### PR DESCRIPTION
1.Sometimes people just want underline only, without background colour, so I add background colour enabler.
2.As background colour and underline are selectable, I add makeLineStyleAttr method to deal with style attributes.  And when both of them unchecked, no need to update highlight line.
3.Even I want to remove the "enable" checkbox, because Atom setting page have own "Enable/Disable" button.  But I noticed you want to add some hotkey to enable/disable highlight line, maybe keep a main flag to control is good idea.
4.I think "enable" checkbox should be first, above the "backgroundRgbColor", so change the name to "AllEnable".
