### PR TITLE
Handle opacity percentages better

### DIFF
--- a/lib/highlight-line-view.coffee
+++ b/lib/highlight-line-view.coffee
@@ -124,6 +124,4 @@ class HighlightLineView extends View
       wantedOpacity = parseFloat(wantedOpacity)
     else
       wantedOpacity = @defaultOpacity
-    if wantedOpacity isnt 100
-      wantedOpacity = "0.#{wantedOpacity}"
-    wantedOpacity
+    (wantedOpacity/100).toString()


### PR DESCRIPTION
I was trying to set the opacity of the highlight to 5%, but `parseFloat("5%")` is `5` and `"0.#{5}"` becomes `0.5` or 50%.

Dividing by 100 and returning seems to work much better in this situation. Note that the check for whether the opacity was 100 meant that if 100 was set the value returned was 100, leaving the rgba value as `rgba(r, g, b, 100)` this fix makes that `rgba(r, g, b, 1)`.
