### PR TITLE
fixed the highlight style doesn't remove.

### DIFF
--- a/lib/highlight-line-view.coffee
+++ b/lib/highlight-line-view.coffee
@@ -111,7 +111,8 @@ class HighlightLineView extends View
     @showHighlight()
 
   resetBackground: ->
-    $('.line').css('border-top','')
+    $('.line').css('background-color','')
+              .css('border-top','')
               .css('border-bottom','')
               .css('margin-bottom','')
               .css('margin-top','')


### PR DESCRIPTION
Hello @richrace 

If I move the cursor, the highlight line doesn't be removed.
![2014-07-21 12 59 36](https://cloud.githubusercontent.com/assets/1680868/3640042/531f08b4-1094-11e4-98e6-7fef44394eba.png)

My settings is default.
![2014-07-21 12 59 53](https://cloud.githubusercontent.com/assets/1680868/3640044/617a3a50-1094-11e4-8667-2c4ebed41c46.png)
