### PR TITLE
fix for empty line selection

### DIFF
--- a/lib/highlight-line-view.coffee
+++ b/lib/highlight-line-view.coffee
@@ -78,7 +78,8 @@ class HighlightLineView extends View
         bottomLine = selectionRange.copy()
 
         topLine.end = topLine.start
-        bottomLine.start = new Point((bottomLine.end.row - 1), bottomLine.end.column)
+        bottomLine.start = new Point(bottomLine.end.row - 1,
+                                     bottomLine.end.column)
 
         style = atom.config.get "highlight-line.underline"
 

--- a/lib/highlight-line-view.coffee
+++ b/lib/highlight-line-view.coffee
@@ -1,5 +1,6 @@
 {View} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
+{Point} = require 'atom'
 
 lines = []
 
@@ -77,7 +78,7 @@ class HighlightLineView extends View
         bottomLine = selectionRange.copy()
 
         topLine.end = topLine.start
-        bottomLine.start = bottomLine.end
+        bottomLine.start = new Point((bottomLine.end.row - 1), bottomLine.end.column)
 
         style = atom.config.get "highlight-line.underline"
 


### PR DESCRIPTION
When i try to highlight bottom line with `underline` it looks weird, can you check it out ? I am not sure my fix is correct 

BTW I use `vim-mode` not sure but this can interfere as well 

![Multi line selection](https://www.evernote.com/shard/s3/sh/aa669fc9-d321-47d3-8e32-582c762645c2/e25ddd8849ac4fd0/res/d0ba02f9-f4bd-4245-8d37-40265e62aa73/skitch.png?resizeSmall&width=832)