### PR TITLE
Fix Issue #80

### DIFF
--- a/lib/highlight-line-model.coffee
+++ b/lib/highlight-line-model.coffee
@@ -69,8 +69,9 @@ class HighlightLineView
         bottomLine = selectionRange.copy()
 
         topLine.end = topLine.start
-        bottomLine.start = new Point(bottomLine.end.row - 1,
-                                     bottomLine.end.column)
+        bottomLine.start = bottomLine.end
+        if bottomLine.start.column == 0
+          bottomLine.start.row -= 1
 
         style = atom.config.get "highlight-line.underline"
 


### PR DESCRIPTION
Issue Link: #80

The middle row referenced in the issue appeared because `bottomLine` began on the second to last row and ended on the last row. That only gave the desired effect when the last row of the selection was empty.

This change only sets the start of the bottom line one row higher if the last row of the selection is empty.